### PR TITLE
Introduced a max. open file descriptor check function to the storage sweep tools

### DIFF
--- a/contrib/storage_sweep/README.md
+++ b/contrib/storage_sweep/README.md
@@ -7,7 +7,9 @@ Chin Fang <`fangchin[at]zettar.com`>, Palo Alto, California, U.S.A
 Engineering](https://www.artima.com/intv/garden.html) 
 
 <a name="page_top"></a>
-Table of contents
+# Table of contents
+<details>
+<summary><b>(click to expand)</b></summary>
 =================
 
    * [Introduction](#introduction)
@@ -27,6 +29,7 @@ Table of contents
    * [Future evolution](#future-evolution)
    * [Acknowledgments](#acknowledgments)
    * [Epilogue](#epilogue)
+</details>
 
 # Introduction
 
@@ -73,10 +76,13 @@ Before proceeding, you may wish to browse the
    time*!
 2. `elbencho` version 1.6.x or later must be installed and available
    in the `root`'s `$PATH`.
-3. Both `mtelbencho.sh` and `graph_sweep.sh` must be install in
-   a directory that is part of the `root`'s `$PATH`. The key reason
-   is that `mtelbencho.sh` runs `elbencho` with its `--dropcache`
-   option, which demands `root` privilege.
+3. Both `mtelbencho.sh` and `graph_sweep.sh` are installed together
+   with `elbencho` RPM or DEB packages, likewise, when the `make
+   install` is issued.  Please note that you need to be `root` to
+   actually run both.  The key reason is that `mtelbencho.sh` runs
+   `elbencho` with its `--dropcache` option, which demands `root`
+   privilege.  You can run the dry-run mode `-n` without being a
+   `root` however.
    
 Note also that your storage must be reasonably fast (*i.e. capable of
 attaining a write throughput level >= 10Gbps with appropriately sized
@@ -89,6 +95,7 @@ testbed](https://youtube.com/watch?v=5qTpGg57p_o), using any one of
 the two nodes (*each has a Linux software RAID 0 based on 8xNVMe
 SSDs - Intel DC P3700 1.6TB U.2*), the following provides single-run
 (`-N 1`) sweep timing information:
+
 |**Range**  | Test duration |
 |-----------|---------------|
 |**LOSF**   | 35m:58s       |
@@ -259,7 +266,7 @@ characteristics to one or more selected target application(s).
 ## How it should be done
 
 1. Always configure the benchmark as closely as possible to the target
-   application's I/O patterns and storage interactions.
+   application (e.g. a database)'s I/O patterns and storage interactions.
 2. If the target application is a host-oriented one, such as a typical
    database application, then the storage benchmarking should be
    carried out on a single **storage client host** (*identical in
@@ -286,10 +293,10 @@ characteristics to one or more selected target application(s).
    service than any other application. The author of a storage
    benchmark cannot know every application out there and be so
    magical.
-3. The main value of a storage benchmark is to enable you to
-   reasonably easily estimate the attainable read/write throughput in
-   one or more storage clients (*if cluster*) to a target
-   application. Period.
+3. The main value of a storage benchmark is to enable you to easily
+   estimate the attainable read/write throughput available to a target
+   application. The application could be running in one or more
+   storage clients.
 
 Furthermore, we often read that a storage service can provide,
 e.g. 1TB/s throughput :grin:.

--- a/contrib/storage_sweep/graph_sweep.sh
+++ b/contrib/storage_sweep/graph_sweep.sh
@@ -87,7 +87,11 @@ dry_run=
 #
 # The two tools that this wrapper is used for.
 #
-mtelbencho=./mtelbencho.sh
+mtelbencho=$(command -v mtelbencho.sh)
+if [[ -z "$mtelbencho" ]]; then
+    echo "mtelbencho.sh could not be found. Aborting!"
+    exit
+fi
 gnuplot=/usr/bin/gnuplot
 #
 # The sweep data file to be plotted using gnuplot. The CSV format is
@@ -529,6 +533,12 @@ show_elbencho_version()
     echo "$vs"
 }
 
+show_installed_sweep_tools()
+{
+    echo "graph_sweep.sh is installed at $(command -v graph_sweep.sh)"
+    echo "mtelbencho.sh is installed at $(command -v mtelbencho.sh)"
+}
+
 show_option_settings()
 {
     echo "range_to_sweep  : $range_to_sweep"
@@ -628,6 +638,7 @@ show_test_duration()
     sweep_gplt="$output_dir"/sweep.gplt
     sweep_svg="$output_dir"/sweep.svg
     [[ "$verbose" ]] && show_elbencho_version
+    [[ "$verbose" ]] && show_installed_sweep_tools
     [[ "$verbose" ]] && show_option_settings
     check_space_available
     [[ -z "$dry_run" ]] && verify_directory_exists "$src_data_dir"


### PR DESCRIPTION
Both `mtelbencho.sh` and `graph_sweep.sh` now has a new function `set_max_open_file_descriptors()`. If the toolset is used in an environment with low `ulimit -Hn` or `ulimit -Sn` or both, the low value(s) are automatically set higher so that the toolset can operate error-free.  The higher values are used only during the sweep and only for the toolset's use. The system values are left alone.
