### PR TITLE
Introduced hostname -s support 

### DIFF
--- a/contrib/storage_sweep/graph_sweep.sh
+++ b/contrib/storage_sweep/graph_sweep.sh
@@ -245,7 +245,7 @@ check_space_available()
     fi
     local sa
     # The df man page states that SIZE units default to 1024 bytes
-    sa=$(df $src_data_dir|tail -1|awk '{ printf "%.0f", $4*1024 }')
+    sa=$(df "$src_data_dir"|tail -1|awk '{ printf "%.0f", $4*1024 }')
     [[ "$verbose" ]] && echo "Space availability now is: $sa bytes."
     [[ "$verbose" ]] && echo "Minimal requirement is   : $minimal_space bytes."
     if [[ "$sa" -lt "$minimal_space" ]]; then
@@ -395,11 +395,13 @@ run_gnuplot()
     else
 	speed='Gbps'
     fi
+    local hn
+    hn=$(hostname -s)
     read -r -d '' gnuplot_settings <<EOF
 #set terminal eps          # tested
 #set terminal pdfcairo     # tested
 set terminal svg enhanced background rgb 'white' # look bad if no background
-set title "Storage sweep for $range over $num_sweep runs on $today"
+set title "Storage sweep on $hn for $range over $num_sweep runs on $today"
 set title font "Times Bold, 14"
 set xlabel 'Datasets'
 set xlabel font "Times Bold,10"


### PR DESCRIPTION
Introduced hostname -s support such that the title of a gnuplot-generated storage sweep plot shows the host on which the task is done. Furthermore, now the entire script is warning-free on https://shellcheck.net/.