### PR TITLE
Added `--s3multiignore404` to ignore 404 errors on MPU completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v3.0.16 (work in progress)
 
+### New Features & Enhancements
+* Added option to ignore 404 errors on multiple retries of MultipartUploadComplete requests (See `--s3multiignore404`)
+
 ### General Changes
 * Use latest Alpine Linux 3.x for Alpine-based docker containers instead of always 3.14.
 * Updated CentOS 7 dockerfiles to vault repo due to EOL.
@@ -21,7 +24,7 @@
 ## v3.0.13 (June 16, 2024)
 
 ### Fixes
-* Fixed memory mamangement for various S3 requests. (Regression from v3.0.9)
+* Fixed memory management for various S3 requests. (Regression from v3.0.9)
 
 ## v3.0.11 (June 11, 2024)
 

--- a/dist/etc/bash_completion.d/elbencho
+++ b/dist/etc/bash_completion.d/elbencho
@@ -131,6 +131,7 @@ _elbencho_opts()
         --s3listobjpar
         --s3listverify
         --s3log
+        --s3multiignore404
         --s3nocompress
         --s3nomd5
         --s3objprefix

--- a/source/ProgArgs.cpp
+++ b/source/ProgArgs.cpp
@@ -540,6 +540,12 @@ void ProgArgs::defineAllowedArgs()
 			"typical max value. Use \"--" ARG_S3OBJECTPREFIX_LONG "\" to list/delete only objects "
 			"with the given prefix. (Multiple threads will only be effecive if multiple buckets "
 			"are given.)")
+/*s3m*/	(ARG_S3MULTI_IGNORE_404, bpo::value(&this->s3IgnoreMultipartUpload404),
+            "Ignores a specific 404 error in multipart uploads, that can happen if the AWS client "
+            "doesn't get a response on a CompleteMultipartUpload request and sends another one. "
+            "Depending on how the S3 backend handles this, it might return a 404 because the upload "
+            "was already completed beforehand. "
+            "Enabling this will ignore 404 errors if the client retried the request")
 /*s3n*/ (ARG_S3NOCOMPRESS_LONG, bpo::bool_switch(&this->s3NoCompression),
             "Disable S3 request compression.")
 /*s3n*/ (ARG_S3NOMD5_LONG, bpo::bool_switch(&this->s3NoMD5Checksum),
@@ -3088,6 +3094,7 @@ void ProgArgs::setFromPropertyTreeForService(bpt::ptree& tree)
 	runS3ListObjNum = tree.get<uint64_t>(ARG_S3LISTOBJ_LONG);
 	runS3ListObjParallel = tree.get<bool>(ARG_S3LISTOBJPARALLEL_LONG);
 	runS3MultiDelObjNum = tree.get<uint64_t>(ARG_S3MULTIDELETE_LONG);
+    runS3MultiDelObjNum = tree.get<bool>(ARG_S3MULTI_IGNORE_404);
 	runS3StatDirs = tree.get<bool>(ARG_S3STATDIRS_LONG);
 	runStatFilesPhase = tree.get<bool>(ARG_STATFILES_LONG);
 	runSyncPhase = tree.get<bool>(ARG_SYNCPHASE_LONG);
@@ -3244,6 +3251,7 @@ void ProgArgs::getAsPropertyTreeForService(bpt::ptree& outTree, size_t serviceRa
 	outTree.put(ARG_S3LISTOBJPARALLEL_LONG, runS3ListObjParallel);
 	outTree.put(ARG_S3LISTOBJVERIFY_LONG, doS3ListObjVerify);
 	outTree.put(ARG_S3MULTIDELETE_LONG, runS3MultiDelObjNum);
+    outTree.put(ARG_S3MULTI_IGNORE_404, s3IgnoreMultipartUpload404);
     outTree.put(ARG_S3NOCOMPRESS_LONG, s3NoCompression);
     outTree.put(ARG_S3NOMD5_LONG, s3NoMD5Checksum);
     outTree.put(ARG_S3STATDIRS_LONG, runS3StatDirs);

--- a/source/ProgArgs.h
+++ b/source/ProgArgs.h
@@ -437,7 +437,6 @@ class ProgArgs
 		uint64_t runS3ListObjNum; // run seq list objects phase if >0, given number is listing limit
 		bool runS3ListObjParallel; // multi-threaded object listing (requires "-n" / "-N")
 		uint64_t runS3MultiDelObjNum; // run S3 multi del phase if >0; number is multi del limit
-        bool s3IgnoreMultipartUpload404; // Ignore 404 on retries of MPU completion
 		bool runServiceInForeground; // true to not daemonize service process into background
 		bool runStatFilesPhase; // stat files
 		bool runSyncPhase; // run the sync() phase to commit all dirty page cache buffers
@@ -450,6 +449,7 @@ class ProgArgs
 		std::string s3EndpointsServiceOverrideStr; // override of s3EndpointStr in service mode
 		StringVec s3EndpointsVec; // s3 endpoints broken down into individual elements
 		std::string s3EndpointsStr; // user-given s3 endpoints; elem format: [http(s)://]host[:port]
+        bool s3IgnoreMultipartUpload404; // Ignore 404 on retries of MPU completion
 		std::string s3LogfilePrefix; // dir and name prefix of aws sdk log file
 		unsigned short s3LogLevel; // log level for AWS SDK
 		bool s3NoCompression; // disable request compression of aws sdk cpp
@@ -668,7 +668,6 @@ class ProgArgs
         bool getRunListObjParallelPhase() const { return runS3ListObjParallel; }
         bool getRunListObjPhase() const { return (runS3ListObjNum > 0); }
         bool getRunMultiDelObjPhase() const { return (runS3MultiDelObjNum > 0); }
-        bool getS3IgnoreMultipartUpload404() const { return s3IgnoreMultipartUpload404; }
         bool getRunReadPhase() const { return runReadPhase; }
         bool getRunS3AclPut() const { return runS3AclPut; }
         bool getRunS3AclGet() const { return runS3AclGet; }
@@ -687,6 +686,7 @@ class ProgArgs
         std::string getS3EndpointsServiceOverride() const { return s3EndpointsServiceOverrideStr; }
         std::string getS3EndpointsStr() const { return s3EndpointsStr; }
         const StringVec& getS3EndpointsVec() const { return s3EndpointsVec; }
+        bool getS3IgnoreMultipartUpload404() const { return s3IgnoreMultipartUpload404; }
         uint64_t getS3ListObjNum() const { return runS3ListObjNum; }
         unsigned short getS3LogLevel() const { return s3LogLevel; }
         std::string getS3LogfilePrefix() const { return s3LogfilePrefix; }

--- a/source/ProgArgs.h
+++ b/source/ProgArgs.h
@@ -158,6 +158,7 @@ namespace bpt = boost::property_tree;
 #define ARG_S3LOGFILEPREFIX_LONG	"s3logprefix"
 #define ARG_S3LOGLEVEL_LONG			"s3log"
 #define ARG_S3MULTIDELETE_LONG		"s3multidel"
+#define ARG_S3MULTI_IGNORE_404      "s3multiignore404"
 #define ARG_S3NOCOMPRESS_LONG       "s3nocompress"
 #define ARG_S3NOMD5_LONG            "s3nomd5"
 #define ARG_S3NOMPCHECK_LONG		"s3nompcheck"
@@ -436,6 +437,7 @@ class ProgArgs
 		uint64_t runS3ListObjNum; // run seq list objects phase if >0, given number is listing limit
 		bool runS3ListObjParallel; // multi-threaded object listing (requires "-n" / "-N")
 		uint64_t runS3MultiDelObjNum; // run S3 multi del phase if >0; number is multi del limit
+        bool s3IgnoreMultipartUpload404; // Ignore 404 on retries of MPU completion
 		bool runServiceInForeground; // true to not daemonize service process into background
 		bool runStatFilesPhase; // stat files
 		bool runSyncPhase; // run the sync() phase to commit all dirty page cache buffers
@@ -666,6 +668,7 @@ class ProgArgs
         bool getRunListObjParallelPhase() const { return runS3ListObjParallel; }
         bool getRunListObjPhase() const { return (runS3ListObjNum > 0); }
         bool getRunMultiDelObjPhase() const { return (runS3MultiDelObjNum > 0); }
+        bool getS3IgnoreMultipartUpload404() const { return s3IgnoreMultipartUpload404; }
         bool getRunReadPhase() const { return runReadPhase; }
         bool getRunS3AclPut() const { return runS3AclPut; }
         bool getRunS3AclGet() const { return runS3AclGet; }


### PR DESCRIPTION
Added a parameter that ignores a specific 404 error in multipart uploads.
This error can happen if the AWS client doesn't get a response on a CompleteMultipartUpload request and sends another one. Depending on how the S3 backend handles this, it might return a 404 because the upload was already completed beforehand. Enabling this parameter will ignore 404 errors if the client retried the request