### PR TITLE
Removed retry count check when ignoring mpu 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v3.0.17 (July 31, 2024)
 
 ### New Features & Enhancements
-* Added option to ignore 404 errors on multiple retries of MultipartUploadComplete requests. (See `--s3multiignore404`.)
+* Added option to ignore 404 errors in MultipartUploadComplete responses. (See `--s3multiignore404`.)
 
 ### General Changes
 * Use latest Alpine Linux 3.x for Alpine-based docker containers instead of always 3.14.

--- a/source/ProgArgs.cpp
+++ b/source/ProgArgs.cpp
@@ -542,10 +542,10 @@ void ProgArgs::defineAllowedArgs()
 			"are given.)")
 /*s3m*/	(ARG_S3MULTI_IGNORE_404, bpo::bool_switch(&this->s3IgnoreMultipartUpload404),
             "Ignore 404 HTTP error code for multipart upload completions, which can happen if the "
-            "CompleteMultipartUpload request has to be retried, e.g. because of a failure. "
+            "CompleteMultipartUpload request has to be retried, e.g. because of a connection failure. "
             "Depending on how the S3 backend handles this, it might return a 404 because the "
             "upload was already completed beforehand. "
-            "Enabling this will ignore 404 HTTP errors if the client retried the request.")
+            "Enabling this will ignore 404 HTTP errors in CompleteMultiPartUpload responses")
 /*s3n*/ (ARG_S3NOCOMPRESS_LONG, bpo::bool_switch(&this->s3NoCompression),
             "Disable S3 request compression.")
 /*s3n*/ (ARG_S3NOMD5_LONG, bpo::bool_switch(&this->s3NoMD5Checksum),

--- a/source/workers/LocalWorker.cpp
+++ b/source/workers/LocalWorker.cpp
@@ -4635,7 +4635,6 @@ void LocalWorker::s3ModeUploadObjectMultiPart(std::string bucketName, std::strin
         auto s3Error = completionOutcome.GetError();
 
         if (!(progArgs->getS3IgnoreMultipartUpload404() &&
-              completionOutcome.GetRetryCount() > 1 &&
               s3Error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND))
         {
             s3AbortMultipartUpload(bucketName, objectName, uploadID);
@@ -4826,7 +4825,6 @@ void LocalWorker::s3ModeUploadObjectMultiPartShared(std::string bucketName, std:
         auto s3Error = completionOutcome.GetError();
 
         if (!(progArgs->getS3IgnoreMultipartUpload404() &&
-              completionOutcome.GetRetryCount() > 1 &&
               s3Error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND))
         {
             s3AbortMultipartUpload(bucketName, objectName, uploadID);


### PR DESCRIPTION
AWS SDK doesn't report the retry count accurately, and I got multiple occurences of AWS retrying but reporting 0 retries