### PR TITLE
Added basic cors support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 # Misc
 excluded/
 todo.txt
+
+# Misc (Mac)
+.DS_Store

--- a/dist/etc/bash_completion.d/elbencho
+++ b/dist/etc/bash_completion.d/elbencho
@@ -129,6 +129,7 @@ _elbencho_opts()
         --s3bversion
         --s3bversionverify
         --s3chksumalgo
+        --s3corsorigin
         --s3endpoints
         --s3fastget
         --s3fastput
@@ -271,6 +272,8 @@ _elbencho()
         --s3aclgtype)
         ;&
         --s3chksumalgo)
+        ;&
+        --s3corsorigin)
         ;&
         --s3endpoints)
         ;&

--- a/source/Common.h
+++ b/source/Common.h
@@ -61,6 +61,8 @@ typedef std::vector<uint64_t> UInt64Vec;
 #define PHASENAME_PUTBUCKETMETADATA     "PUTBUCKETMD"
 #define PHASENAME_DELBUCKETMETADATA     "DELBUCKETMD"
 
+#define REQUEST_ORIGIN_HEADER   "Origin"
+#define RESPONSE_ORIGIN_HEADER  "Access-Control-Allow-Origin"
 
 // human-readable entry type in current benchmark phase
 

--- a/source/ProgArgs.cpp
+++ b/source/ProgArgs.cpp
@@ -557,6 +557,10 @@ void ProgArgs::defineAllowedArgs()
 /*s3c*/	(ARG_S3CHECKSUM_ALGO_LONG, bpo::value(&this->s3ChecksumAlgoStr),
             "S3 checksum algorithm to use (CRC32, CRC32C, SHA1, SHA256). This sets the "
             "x-amz-sdk-checksum-algorithm header for S3 operations. (EXPERIMENTAL)")
+/*s3c*/	(ARG_S3CORSORIGIN_LONG, bpo::value(&this->s3CorsOrigin),
+            "S3 CORS origin header value. When provided, elbencho will add the '" REQUEST_ORIGIN_HEADER 
+            "' header to S3 requests and validate the '" RESPONSE_ORIGIN_HEADER "' response header.")
+
 /*s3e*/	(ARG_S3ENDPOINTS_LONG, bpo::value(&this->s3EndpointsStr),
 			"Comma-separated list of S3 endpoints. When this argument is used, the given "
 			"benchmark paths are used as bucket names. Also see \"--" ARG_S3ACCESSKEY_LONG "\" & "
@@ -896,6 +900,7 @@ void ProgArgs::defineDefaults()
 	this->s3IgnoreMultipartUpload404 = false;
 	this->stdoutDupFD = -1;
     this->s3ChecksumAlgoStr = "";  // Default to empty string (resolved as NOT_SET)
+    this->s3CorsOrigin = "";  // Default to empty string (CORS testing disabled)
 }
 
 /**
@@ -3375,6 +3380,7 @@ void ProgArgs::setFromPropertyTreeForService(bpt::ptree& tree)
 	s3SignPolicy = tree.get<unsigned short>(ARG_S3SIGNPAYLOAD_LONG);
     s3SSECKey = tree.get<std::string>(ARG_S3SSECKEY_LONG);
     s3SSEKMSKey = tree.get<std::string>(ARG_S3SSEKMSKEY_LONG);
+    s3CorsOrigin = tree.get<std::string>(ARG_S3CORSORIGIN_LONG);
 	sockRecvBufSize = tree.get<int>(ARG_RECVBUFSIZE_LONG);
 	sockSendBufSize = tree.get<int>(ARG_SENDBUFSIZE_LONG);
 	treeRoundUpSize = tree.get<uint64_t>(ARG_TREEROUNDUP_LONG);
@@ -3532,6 +3538,7 @@ void ProgArgs::getAsPropertyTreeForService(bpt::ptree& outTree, size_t serviceRa
     outTree.put(ARG_S3SSE_LONG, useS3SSE);
     outTree.put(ARG_S3SSECKEY_LONG, s3SSECKey);
     outTree.put(ARG_S3SSEKMSKEY_LONG, s3SSEKMSKey);
+    outTree.put(ARG_S3CORSORIGIN_LONG, s3CorsOrigin);
 	outTree.put(ARG_SENDBUFSIZE_LONG, sockSendBufSize);
 	outTree.put(ARG_STATFILES_LONG, runStatFilesPhase);
 	outTree.put(ARG_STATFILESINLINE_LONG, doStatInline);

--- a/source/ProgArgs.h
+++ b/source/ProgArgs.h
@@ -182,6 +182,7 @@ namespace bpt = boost::property_tree;
 #define ARG_S3CHECKSUM_ALGO_LONG    "s3chksumalgo"  // parameter for x-amz-sdk-checksum-algorithm
 #define ARG_S3SSEKMSKEY_LONG        "s3ssekmskey"
 #define ARG_S3STATDIRS_LONG         "s3statdirs"
+#define ARG_S3CORSORIGIN_LONG       "s3corsorigin"
 #define ARG_SENDBUFSIZE_LONG		"sendbuf"
 #define ARG_SERVERS_LONG			"servers"
 #define ARG_SERVERSFILE_LONG		"serversfile"
@@ -485,6 +486,7 @@ class ProgArgs
 			"2=never" is ignored, because as of aws sdk cpp v1.11.486 signing is always done. */
         std::string s3SSECKey;  // S3 SSE-C key for encryption
         std::string s3SSEKMSKey;  // S3 SSE-KMS key for encryption
+        std::string s3CorsOrigin;  // S3 CORS Origin header for testing
 		unsigned short servicePort; // HTTP/TCP port for service
 		std::string serversFilePath; // path to file for preprended service hosts
 		std::string serversStr; // prepended to hostsStr in netbench mode
@@ -737,6 +739,8 @@ class ProgArgs
         unsigned short getS3SignPolicy() const { return s3SignPolicy; }
         std::string getS3SSECKey() const { return s3SSECKey; }
         std::string getS3SSEKMSKey() const { return s3SSEKMSKey; }
+        const std::string& getS3CorsOrigin() const { return s3CorsOrigin; }
+        bool getDoS3CorsTest() const { return !s3CorsOrigin.empty(); }
         unsigned short getServicePort() const { return servicePort; }
         bool getShowAllElapsed() const { return showAllElapsed; }
         bool getShowCPUUtilization() const { return showCPUUtilization; }

--- a/source/workers/LocalWorker.cpp
+++ b/source/workers/LocalWorker.cpp
@@ -4158,6 +4158,54 @@ void LocalWorker::s3ModeThrowOnError(
     throw WorkerException(errStr.str());
 
 }
+
+/**
+ * Throw a WorkerException if the s3 response header does not match the expected value.
+ * 
+ * @outcome s3 request outcome.
+ * @bucketName name of bucket to which this error applies, can be empty.
+ * @objectName name of object to which this error applies, can be empty.
+ * @throw WorkerException on error.
+ */
+template <typename R>
+void LocalWorker::s3ModeThrowOnCorsError(
+    const Aws::Utils::Outcome<R, S3ErrorType>& outcome, 
+    const std::string& bucketName, 
+    const std::string& objectName)
+{
+    if (!progArgs->getDoS3CorsTest()) return;
+
+    std::stringstream errStr;
+
+    switch (lastCorsResult) 
+    {
+        case CorsResult::OK:
+            // Set the lastCorsResult to NOT_SET, this marks that the result was checked
+            lastCorsResult = CorsResult::NOT_SET;
+            return;
+        case CorsResult::MISSING:
+            errStr << "CORS header missing: '" RESPONSE_ORIGIN_HEADER "'" << std::endl;
+            break;
+        case CorsResult::MISMATCH:
+            errStr << "CORS Mismatch in '" RESPONSE_ORIGIN_HEADER "' header" << std::endl 
+                   << "Expected: " << progArgs->getS3CorsOrigin() << std::endl
+                   << "Received: " << lastMismatchedOriginHeader << std::endl;
+            break;
+        case CorsResult::NOT_SET:
+            errStr << "Runtime error, cors result is NOT_SET" << std::endl;
+            break;
+    }
+    errStr << "Object: " << bucketName;
+
+    if (objectName.length())
+        errStr << "/" << objectName;
+
+
+    errStr << std::endl 
+           << "During phase: " << TranslatorTk::benchPhaseToPhaseName(workersSharedData->currentBenchPhase, progArgs) << std::endl;
+
+    throw WorkerException(errStr.str());
+}
 #endif // S3_SUPPORT
 
 /**
@@ -4200,6 +4248,48 @@ void LocalWorker::s3ModeAddChecksumAlgorithm(REQUESTTYPE& request)
 #endif // S3_SUPPORT
 }
 
+template <typename REQUESTTYPE>
+void LocalWorker::s3ModeAddCorsHeader(REQUESTTYPE& request)
+{
+#ifndef S3_SUPPORT
+    throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
+#else
+
+    if (!progArgs->getDoS3CorsTest()) return;
+
+    // Make sure that the lastCorsResult is NOT_SET, that means it was checked (or on first run)
+    IF_UNLIKELY(lastCorsResult != CorsResult::NOT_SET)
+        throw WorkerException("Elbencho runtime error: lastCorsResult is discarded at " 
+            + std::string(__func__));
+    
+    request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
+    
+    request.SetHeadersReceivedEventHandler(
+        [&](const Aws::Http::HttpRequest *request, Aws::Http::HttpResponse *response)
+        {
+            const auto &cors_header = response->GetHeader(RESPONSE_ORIGIN_HEADER);
+
+            IF_UNLIKELY(cors_header.empty())
+            {
+                lastCorsResult = CorsResult::MISSING;
+                return;
+            }
+
+            const Aws::String expected_origin = progArgs->getS3CorsOrigin().c_str();
+
+            IF_UNLIKELY(cors_header != "*" && cors_header != expected_origin)
+            {
+                lastCorsResult = CorsResult::MISMATCH;
+                lastMismatchedOriginHeader = cors_header;
+                return;
+            }
+
+            lastCorsResult = CorsResult::OK;
+        });
+
+#endif // S3_SUPPORT
+}
+
 /**
  * Create given S3 bucket.
  *
@@ -4211,9 +4301,13 @@ void LocalWorker::s3ModeCreateBucket(std::string bucketName)
     throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
 #else
 
+	auto request = S3::CreateBucketRequest().WithBucket(bucketName);
+
+	// s3ModeAddCorsHeader(request);
+
     OPLOG_PRE_OP("S3CreateBucket", bucketName, 0, 0);
 
-    const auto createOutcome = s3Client->CreateBucket(S3::CreateBucketRequest().WithBucket(bucketName));
+    const auto createOutcome = s3Client->CreateBucket(request);
 
     OPLOG_POST_OP("S3CreateBucket", bucketName, 0, 0, !createOutcome.IsSuccess());
 
@@ -4242,9 +4336,15 @@ void LocalWorker::s3ModeHeadBucket(std::string bucketName)
 #ifndef S3_SUPPORT
 	throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
 #else
+
+    auto request = S3::HeadBucketRequest().WithBucket(bucketName);
+
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
+
     OPLOG_PRE_OP("HeadBucket", bucketName, 0, 0);
 
-	const auto outcome = s3Client->HeadBucket(S3::HeadBucketRequest().WithBucket(bucketName));
+	const auto outcome = s3Client->HeadBucket(request);
 
     OPLOG_POST_OP("HeadBucket", bucketName, 0, 0, !outcome.IsSuccess());
 
@@ -4275,6 +4375,9 @@ void LocalWorker::s3ModeCreateBucketTagging(const std::string& bucketName)
     S3::PutBucketTaggingRequest taggingRequest;
     taggingRequest.WithBucket(bucketName).WithTagging(tagging);
 
+    if (progArgs->getDoS3CorsTest())
+        taggingRequest.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
+
     s3ModeAddChecksumAlgorithm(taggingRequest);
 
     OPLOG_PRE_OP("PutBucketTagging", bucketName, 0, 0);
@@ -4298,12 +4401,17 @@ void LocalWorker::s3ModeGetBucketTagging(const std::string& bucketName)
 #ifndef S3_SUPPORT
     throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
 #else
+
+    auto request = S3::GetBucketTaggingRequest().WithBucket(bucketName);
+
+    s3ModeAddCorsHeader(request);
     OPLOG_PRE_OP("GetBucketTagging", bucketName, 0, 0);
 
-    const auto outcome = s3Client->GetBucketTagging(S3::GetBucketTaggingRequest().WithBucket(bucketName));
+    const auto outcome = s3Client->GetBucketTagging(request);
 
     OPLOG_POST_OP("GetBucketTagging", bucketName, 0, 0, !outcome.IsSuccess());
 
+    s3ModeThrowOnCorsError(outcome, bucketName);
     s3ModeThrowOnError(outcome, "Get bucket tagging failed.", bucketName);
 
     if (!progArgs->getDoS3BucketTaggingVerify())
@@ -4335,11 +4443,14 @@ void LocalWorker::s3ModeDeleteBucketTagging(const std::string& bucketName)
 	throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
 #else
 
+    auto request = S3::DeleteBucketTaggingRequest().WithBucket(bucketName);
+
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
+
     OPLOG_PRE_OP("DeleteBucketTagging", bucketName, 0, 0);
 
-    const auto outcome = s3Client->DeleteBucketTagging(
-        S3::DeleteBucketTaggingRequest().WithBucket(bucketName)
-    );
+    const auto outcome = s3Client->DeleteBucketTagging(request);
 
     OPLOG_POST_OP("DeleteBucketTagging", bucketName, 0, 0, !outcome.IsSuccess());
 
@@ -4359,24 +4470,27 @@ void LocalWorker::s3ModeDeleteBucket(const std::string& bucketName)
 	throw WorkerException(std::string(__func__) + " called, but this was built without S3 support");
 #else
 
-	const bool ignoreDelErrors = progArgs->getIgnoreDelErrors();
+    const bool ignoreDelErrors = progArgs->getIgnoreDelErrors();
 
-	S3::DeleteBucketRequest request;
-	request.SetBucket(bucketName);
+    S3::DeleteBucketRequest request;
+    request.SetBucket(bucketName);
 
-	OPLOG_PRE_OP("S3DeleteBucket", bucketName, 0, 0);
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
-	S3::DeleteBucketOutcome deleteOutcome = s3Client->DeleteBucket(request);
+    OPLOG_PRE_OP("S3DeleteBucket", bucketName, 0, 0);
 
-	OPLOG_POST_OP("S3DeleteBucket", bucketName, 0, 0, !deleteOutcome.IsSuccess() );
+    S3::DeleteBucketOutcome deleteOutcome = s3Client->DeleteBucket(request);
 
-	if(!deleteOutcome.IsSuccess() )
-	{
-		auto s3Error = deleteOutcome.GetError();
+    OPLOG_POST_OP("S3DeleteBucket", bucketName, 0, 0, !deleteOutcome.IsSuccess() );
 
-		if( (s3Error.GetErrorType() != S3Errors::NO_SUCH_BUCKET) || !ignoreDelErrors)
+    if(!deleteOutcome.IsSuccess() )
+    {
+        auto s3Error = deleteOutcome.GetError();
+
+        if( (s3Error.GetErrorType() != S3Errors::NO_SUCH_BUCKET) || !ignoreDelErrors)
             s3ModeThrowOnError(deleteOutcome, "Bucket deletion failed.", bucketName);
-	}
+    }
 
 #endif // S3_SUPPORT
 }
@@ -4627,35 +4741,38 @@ void LocalWorker::s3ModeUploadObjectSinglePart(std::string bucketName, std::stri
     request.SetContinueRequestHandler( [&](const Aws::Http::HttpRequest* request)
         { return !isInterruptionRequested.load(); } );
 
-	OPLOG_PRE_OP("S3PutObject", bucketName + "/" + objectName, currentOffset, blockSize);
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
-	S3::PutObjectOutcome outcome = s3Client->PutObject(request);
+    OPLOG_PRE_OP("S3PutObject", bucketName + "/" + objectName, currentOffset, blockSize);
 
-	OPLOG_POST_OP("S3PutObject", bucketName + "/" + objectName, currentOffset, blockSize,
-		!outcome.IsSuccess() );
+    S3::PutObjectOutcome outcome = s3Client->PutObject(request);
 
-	checkInterruptionRequest(); // (placed here to avoid outcome check on interruption)
+    OPLOG_POST_OP("S3PutObject", bucketName + "/" + objectName, currentOffset, blockSize,
+        !outcome.IsSuccess() );
 
-	IF_UNLIKELY(!outcome.IsSuccess() && !ignoreS3Errors)
+    checkInterruptionRequest(); // (placed here to avoid outcome check on interruption)
+
+    IF_UNLIKELY(!outcome.IsSuccess() && !ignoreS3Errors)
         s3ModeThrowOnError(outcome, "Object upload failed.", bucketName, objectName);
 
-	if(blockSize)
-	{
-		((*this).*funcPostReadCudaMemcpy)(ioBufVec[0], gpuIOBufVec[0], blockSize);
-		((*this).*funcPostReadBlockChecker)(ioBufVec[0], gpuIOBufVec[0], blockSize, currentOffset);
-	}
+    if(blockSize)
+    {
+        ((*this).*funcPostReadCudaMemcpy)(ioBufVec[0], gpuIOBufVec[0], blockSize);
+        ((*this).*funcPostReadBlockChecker)(ioBufVec[0], gpuIOBufVec[0], blockSize, currentOffset);
+    }
 
-	// calc io operation latency
-	std::chrono::steady_clock::time_point ioEndT = std::chrono::steady_clock::now();
-	std::chrono::microseconds ioElapsedMicroSec =
-		std::chrono::duration_cast<std::chrono::microseconds>
-		(ioEndT - ioStartT);
+    // calc io operation latency
+    std::chrono::steady_clock::time_point ioEndT = std::chrono::steady_clock::now();
+    std::chrono::microseconds ioElapsedMicroSec =
+        std::chrono::duration_cast<std::chrono::microseconds>
+        (ioEndT - ioStartT);
 
-	iopsLatHisto.addLatency(ioElapsedMicroSec.count() );
+    iopsLatHisto.addLatency(ioElapsedMicroSec.count() );
 
-	numIOPSSubmitted++;
-	rwOffsetGen->addBytesSubmitted(blockSize);
-	atomicLiveOps.numIOPSDone++;
+    numIOPSSubmitted++;
+    rwOffsetGen->addBytesSubmitted(blockSize);
+    atomicLiveOps.numIOPSDone++;
 
 #endif // S3_SUPPORT
 }
@@ -4686,6 +4803,9 @@ void LocalWorker::s3ModeUploadObjectMultiPart(std::string bucketName, std::strin
 
     if(doS3AclPutInline)
         TranslatorTk::applyS3PutObjectAclGrants(progArgs, createMultipartUploadRequest);
+
+    if (progArgs->getDoS3CorsTest())
+        createMultipartUploadRequest.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
     OPLOG_PRE_OP("S3CreateMultipartUpload", bucketName + "/" + objectName, 0, 0);
 
@@ -4752,6 +4872,9 @@ void LocalWorker::s3ModeUploadObjectMultiPart(std::string bucketName, std::strin
 
 		uploadPartRequest.SetContinueRequestHandler( [&](const Aws::Http::HttpRequest* request)
 			{ return !isInterruptionRequested.load(); } );
+
+        if (progArgs->getDoS3CorsTest())
+            uploadPartRequest.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
 		OPLOG_PRE_OP("S3UploadPart", bucketName + "/" + objectName, currentPartNum, blockSize);
 
@@ -4836,6 +4959,9 @@ void LocalWorker::s3ModeUploadObjectMultiPart(std::string bucketName, std::strin
         completionRequest.WithSSECustomerAlgorithm("AES256")
                 .WithSSECustomerKey(s3SSECKey)
                 .WithSSECustomerKeyMD5(s3SSECKeyMD5);
+
+    if (progArgs->getDoS3CorsTest())
+        completionRequest.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
     OPLOG_PRE_OP("S3CompleteMultipartUpload", bucketName + "/" + objectName, 0,
         completedMultipartUpload.GetParts().size() );
@@ -5173,6 +5299,8 @@ void LocalWorker::s3ModeDownloadObject(std::string bucketName, std::string objec
 			.WithKey(objectName)
 			.WithRange(objectRange);
 
+        s3ModeAddCorsHeader(request);
+
         // (no s3ModeAddServerSideEncryptionHeaders() because this one is only for SSE-C)
         if(!s3SSECKey.empty())
             request.WithSSECustomerAlgorithm("AES256")
@@ -5218,6 +5346,8 @@ void LocalWorker::s3ModeDownloadObject(std::string bucketName, std::string objec
 		    !outcome.IsSuccess() );
 
 		checkInterruptionRequest(); // (placed here to avoid outcome check on interruption)
+
+        s3ModeThrowOnCorsError(outcome, bucketName, objectName);
 
 		IF_UNLIKELY(!outcome.IsSuccess() && !ignoreS3Errors)
             s3ModeThrowOnError(outcome, "Object download failed.", bucketName, objectName);
@@ -5300,24 +5430,27 @@ void LocalWorker::s3ModeDeleteObject(std::string bucketName, std::string objectN
 	throw WorkerException(std::string(__func__) + "called, but this was built without S3 support");
 #else
 
-	const bool ignoreDelErrors = progArgs->getIgnoreDelErrors();
+    const bool ignoreDelErrors = progArgs->getIgnoreDelErrors();
 
-	S3::DeleteObjectRequest request;
-	request.WithBucket(bucketName)
-		.WithKey(objectName);
+    S3::DeleteObjectRequest request;
+    request.WithBucket(bucketName)
+        .WithKey(objectName);
 
-	OPLOG_PRE_OP("S3DeleteObject", bucketName + "/" + objectName, 0, 0);
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
-	S3::DeleteObjectOutcome outcome = s3Client->DeleteObject(request);
+    OPLOG_PRE_OP("S3DeleteObject", bucketName + "/" + objectName, 0, 0);
+
+    S3::DeleteObjectOutcome outcome = s3Client->DeleteObject(request);
 
     OPLOG_POST_OP("S3DeleteObject", bucketName + "/" + objectName, 0, 0, !outcome.IsSuccess() );
 
-	IF_UNLIKELY(!outcome.IsSuccess() &&
-		(!ignoreDelErrors ||
-			(outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) ) )
-	{
+    IF_UNLIKELY(!outcome.IsSuccess() &&
+        (!ignoreDelErrors ||
+            (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) ) )
+    {
         s3ModeThrowOnError(outcome, "Object deletion failed.", bucketName, objectName);
-	}
+    }
 
 #endif // S3_SUPPORT
 }
@@ -5874,16 +6007,20 @@ void LocalWorker::s3ModeGetObjectTags(const std::string& bucketName, const std::
 #ifndef S3_SUPPORT
     throw WorkerException(std::string(__func__) + "called, but this was built without S3 support");
 #else
-    OPLOG_PRE_OP("GetObjectTagging", bucketName + "/" + objectName, 0, 0);
 
-    const auto getTagOutcome = s3Client->GetObjectTagging(
-        S3::GetObjectTaggingRequest()
-            .WithBucket(bucketName)
-            .WithKey(objectName)
-    );
+    auto request = S3::GetObjectTaggingRequest()
+                       .WithBucket(bucketName)
+                       .WithKey(objectName);
+
+    s3ModeAddCorsHeader(request);
+
+   OPLOG_PRE_OP("GetObjectTagging", bucketName + "/" + objectName, 0, 0);
+
+    const auto getTagOutcome = s3Client->GetObjectTagging(request);
 
     OPLOG_POST_OP("GetObjectTagging", bucketName + "/" + objectName, 0, 0, !getTagOutcome.IsSuccess());
 
+    s3ModeThrowOnCorsError(getTagOutcome, bucketName, objectName);
     s3ModeThrowOnError(getTagOutcome, "Get object tagging failed.", bucketName, objectName);
 
     // Continue only if we need to verify
@@ -5925,10 +6062,14 @@ void LocalWorker::s3ModePutObjectTags(const std::string& bucketName, const std::
         .WithKey(TAG_KEY_MEDIUM_NAME)
         .WithValue(StringTk::generateRandomS3TagValue(objectName, TAG_VALUE_MEDIUM_LEN));
 
-    S3::PutObjectTaggingRequest request;
-    request.WithBucket(bucketName)
-          .WithKey(objectName)
-          .WithTagging(S3::Tagging().AddTagSet(tag));
+    auto request = S3::PutObjectTaggingRequest()
+                       .WithBucket(bucketName)
+                       .WithKey(objectName)
+                       .WithTagging(
+                           S3::Tagging().AddTagSet(tag));
+
+    if (progArgs->getDoS3CorsTest())
+        request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
 
     s3ModeAddChecksumAlgorithm(request);
 
@@ -5950,13 +6091,16 @@ void LocalWorker::s3ModeDeleteObjectTags(const std::string& bucketName, const st
     throw WorkerException(std::string(__func__) + "called, but this was built without S3 support");
 #else
 
+    auto request = S3::DeleteObjectTaggingRequest()
+                       .WithBucket(bucketName)
+                       .WithKey(objectName);
+
+   if (progArgs->getDoS3CorsTest())
+       request.SetAdditionalCustomHeaderValue(REQUEST_ORIGIN_HEADER, progArgs->getS3CorsOrigin());
+               
     OPLOG_PRE_OP("DeleteObjectTagging", bucketName + "/" + objectName, 0, 0);
 
-    const auto delTagOutcome = s3Client->DeleteObjectTagging(
-        S3::DeleteObjectTaggingRequest()
-            .WithBucket(bucketName)
-            .WithKey(objectName)
-    );
+    const auto delTagOutcome = s3Client->DeleteObjectTagging(request);
 
     OPLOG_POST_OP("DeleteObjectTagging", bucketName + "/" + objectName, 0, 0, !delTagOutcome.IsSuccess());
 


### PR DESCRIPTION
This PR adds basic support for S3 CORS.

elbencho will not configure the bucket cors, and will only send an `Origin` header, and expects an `Access-Control-Allow-Origin` header back (with the same value or `*`).

Due to current limitations of the implementation, elbencho doesn't validate the response header in `PUT` or `DELTE` requests, only `GET` requests. This is due to a limitation of the current implementation which uses `SetHeadersReceivedEventHandler`.

This is why `GET` functions use `s3ModeAddCorsHeader` and `s3ModeThrowOnCorsError`, while `PUT` and `DELETE` functions just set the header (invoke `SetAdditionalCustomHeaderValue` directly)