### PR TITLE
Reject dash character in unit conversion to prevent silent misparse

### DIFF
--- a/source/toolkits/UnitTk.cpp
+++ b/source/toolkits/UnitTk.cpp
@@ -35,6 +35,16 @@ uint64_t UnitTk::numHumanToBytesBinary(std::string numHuman, bool throwOnEmpty)
 	if(findCommaPos != std::string::npos)
 		throw ProgException("Unable to parse number string containing ',' character: " + numHuman);
 
+	// make sure number string does not contain "-" character. A leading "-" would be silently
+	// cast to a huge value because the return type is uint64_t, and a "-" in the middle
+	// (e.g. "4k-4m" range) would cause atoll to only parse the leading digits while the unit
+	// suffix is taken from the last character, silently resulting in a wrong value.
+	std::size_t findDashPos = numHuman.find("-");
+	if(findDashPos != std::string::npos)
+		throw ProgException("Unable to parse value: " + numHuman + ". "
+			"A positive number is required (e.g. \"4k\"). "
+			"Negative and range values are not supported.");
+
 	// atoll ignores characters at the end
 	uint64_t bytesRes = std::atoll(numHuman.c_str() );
 


### PR DESCRIPTION
# Summary

Add strict validation in `numHumanToBytesBinary()` to prevent silent misinterpretation of invalid range-like inputs and negative values.

# Issue

`numHumanToBytesBinary()` silently misinterpreted inputs such as "2k-4m" as a single value.

Root cause:
- `atoll()` parses only the leading numeric portion of the string.
- The unit suffix was derived from the final character of the full string.

Example:
- Input: "2k-4m"
- Parsed numeric portion: `2`
- Parsed unit: `m`
- Result: 2 MiB

Instead of rejecting the input, it produced a valid but incorrect value.

# How This Was Discovered

I accidentally passed a range-style argument to elbencho, similar to what fio accepts. Elbencho executed without error.

The issue was later identified while performing detailed CSV result analysis.

# Fix

Added input validation to:

- Detect a '-' anywhere after position 0
- Fail fast with a clear error message

This prevents:
- Range-style inputs
- Negative numbers
- Any ambiguous parsing behavior

The change protects all 14 callers of `numHumanToBytesBinary()`, including:

- `-s`
- `-b`
- `--numfiles`
- `--numdirs`
- All other size, count, and rate parameters

# Negative Numbers

Negative values are now explicitly rejected.

This is correct behavior because:

1. No legitimate negative input exists for these parameters.
2. Previously, negative values were already broken.  
   `atoll("-4k")` cast to `uint64_t` wraps to a massive number, which could lead to allocation failures or undefined benchmark behavior.
3. The fix converts silent corruption into a clear validation error.
4. Zero remains fully supported and unaffected.

In short: negative values were never supported. They were silently mishandled. This change makes the rejection explicit.

# Callers Review

All 14 callers represent non-negative physical concepts:

| Caller | Type | Meaning | Negative Valid? |
|--------|------|---------|-----------------|
| `blockSize` | `size_t` | Bytes per I/O | No |
| `fileSize` | `uint64_t` | File size | No |
| `numDirs` | `size_t` | Directory count | No |
| `numFiles` | `size_t` | File count | No |
| `randomAmount` | `uint64_t` | Random byte amount | No |
| `fileShareSize` | `uint64_t` | Size threshold | No |
| `treeRoundUpSize` | `uint64_t` | Alignment size | No |
| `limitReadBps` | `uint64_t` | Read rate limit | No |
| `limitWriteBps` | `uint64_t` | Write rate limit | No |
| `netBenchRespSize` | `size_t` | Network response size | No |
| `s3MpuSizeVariance` | `size_t` | MPU variance | No |
| `s3MpuSplitSize` | `size_t` | MPU split size | No |
| `sockRecvBufSize` | `int` | Socket recv buffer | No |
| `sockSendBufSize` | `int` | Socket send buffer | No |

The two `int` values use:
- `0` as a sentinel meaning "leave default"
- Positive values to set a buffer size

Negative values would be meaningless for `setsockopt()`.

# Build Verification

Rebuilt successfully:

```
kkhlebop@kkhlebop-mn4245 elbencho % rm -f source/toolkits/UnitTk.o && make source/toolkits/UnitTk.o 2>&1
[OPT] Backtrace support disabled
[OPT] CUFILE (GDS) support disabled
[OPT] CUDA support disabled
[OPT] S3 support disabled. (Enable via S3_SUPPORT=1)
[OPT] mimalloc disabled
[OPT] Alternative HTTP service disabled
[OPT] HDFS support disabled
[DEP] source/toolkits/UnitTk.d
[CXX] source/toolkits/UnitTk.o
```

# Behavior Change

Users who accidentally provide range-style input will now receive a clear validation error instead of silent misinterpretation.

This eliminates a class of hard-to-detect configuration bugs.