### PR TITLE
s3: support AWS CLI v2 env vars for endpoint and region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### General Changes
 * Respect the `AWS_REQUEST_CHECKSUM_CALCULATION` environment variable for S3. Default for checksum calculation is still `when_required` as before, but this can now be changed by setting the environment variable to `when_supported`, which will switch to chunked uploads. (With the `when_suppported` setting, multi-part uploads will switch from fixed content length to chunked encoding and corresponding streaming signatures.)
+* S3 endpoint and region can now also be provided via environment variables to match AWS CLI v2 behavior. `--s3endpoints` falls back to `AWS_ENDPOINT_URL_S3` then `AWS_ENDPOINT_URL`; `--s3region` falls back to `AWS_REGION` then `AWS_DEFAULT_REGION`. Command-line arguments still take precedence.
 * Added check for invalid `-` character in values that don't exect negative numbers or ranges, e.g. filesize or blocksize.
 * Updated S3 to latest AWS SDK CPP v1.11.789.
 * Updated AWS SDK CPP git clone command to only do shallow submodule cloning and to use parallel jobs.

--- a/source/ProgArgs.cpp
+++ b/source/ProgArgs.cpp
@@ -67,6 +67,10 @@
 #define S3_ENV_ACCESS_KEY           "AWS_ACCESS_KEY_ID" // environment variable for s3 access key
 #define S3_ENV_SECRET_KEY           "AWS_SECRET_ACCESS_KEY" // environment variable for s3 secret
 #define S3_ENV_SESSION_TOKEN        "AWS_SESSION_TOKEN" // environment variable for s3 session token
+#define S3_ENV_ENDPOINT_URL_S3      "AWS_ENDPOINT_URL_S3" // S3-specific endpoint URL (AWS CLI v2)
+#define S3_ENV_ENDPOINT_URL         "AWS_ENDPOINT_URL" // generic endpoint URL for all AWS services
+#define S3_ENV_REGION               "AWS_REGION" // AWS region (AWS CLI v2 preferred name)
+#define S3_ENV_REGION_DEFAULT       "AWS_DEFAULT_REGION" // AWS region (legacy name)
 
 // Names of features for printVersionAndBuildInfo()
 #define FEATURE_NAME_S3_SUPPORT     "s3"
@@ -575,7 +579,9 @@ void ProgArgs::defineAllowedArgs()
 /*s3e*/	(ARG_S3ENDPOINTS_LONG, bpo::value(&this->s3EndpointsStr),
 			"Comma-separated list of S3 endpoints. When this argument is used, the given "
 			"benchmark paths are used as bucket names. Also see \"--" ARG_S3ACCESSKEY_LONG "\" & "
-			"\"--" ARG_S3ACCESSSECRET_LONG "\". (Format: [http(s)://]hostname[:port])")
+			"\"--" ARG_S3ACCESSSECRET_LONG "\". (This can also be set via the "
+			S3_ENV_ENDPOINT_URL_S3 " or " S3_ENV_ENDPOINT_URL " env variable.) "
+			"(Format: [http(s)://]hostname[:port])")
 /*s3f*/	(ARG_S3FASTGET_LONG, bpo::bool_switch(&this->useS3FastRead),
 			"Send downloaded objects directly to /dev/null instead of a memory buffer. This option "
 			"is incompatible with any buffer post-processing options like data verification or "
@@ -669,7 +675,8 @@ void ProgArgs::defineAllowedArgs()
 /*s3s*/	(ARG_S3SSEKMSKEY_LONG, bpo::value(&this->s3SSEKMSKey),
             "Key for S3 SSE-KMS. (EXPERIMENTAL)")
 /*s3r*/	(ARG_S3REGION_LONG, bpo::value(&this->s3Region),
-			"S3 region.")
+			"S3 region. (This can also be set via the " S3_ENV_REGION " or "
+			S3_ENV_REGION_DEFAULT " env variable.)")
 /*s3s*/	(ARG_S3ACCESSSECRET_LONG, bpo::value(&this->s3AccessSecret),
 			"S3 access secret. (This can also be set via the " S3_ENV_SECRET_KEY " env variable.)")
 /*s3s*/	(ARG_S3SESSION_TOKEN_LONG, bpo::value(&this->s3SessionToken),
@@ -999,6 +1006,30 @@ void ProgArgs::initImplicitValues()
 
 	if(useBriefLiveStatsNewLine)
 		useBriefLiveStats = true;
+
+	// read s3 endpoint & region from environment variables as fallback when command-line
+	// arguments are not given (matches AWS CLI v2 precedence: arg > env). Not applied when
+	// running as a service, because services inherit these values from the master.
+	if(!runAsService)
+	{
+		if(s3EndpointsStr.empty() )
+		{
+			if(getenv(S3_ENV_ENDPOINT_URL_S3) != NULL)
+				s3EndpointsStr = getenv(S3_ENV_ENDPOINT_URL_S3);
+			else
+			if(getenv(S3_ENV_ENDPOINT_URL) != NULL)
+				s3EndpointsStr = getenv(S3_ENV_ENDPOINT_URL);
+		}
+
+		if(s3Region.empty() )
+		{
+			if(getenv(S3_ENV_REGION) != NULL)
+				s3Region = getenv(S3_ENV_REGION);
+			else
+			if(getenv(S3_ENV_REGION_DEFAULT) != NULL)
+				s3Region = getenv(S3_ENV_REGION_DEFAULT);
+		}
+	}
 
 	// service: check for s3 endpoint override
 	if(!s3EndpointsStr.empty() && runAsService)
@@ -3086,7 +3117,9 @@ void ProgArgs::printHelpS3()
         (ARG_S3CREDLIST_LONG, bpo::value(&this->s3CredentialsList),
             "Comma-separated list of S3 credentials. Each credential in format: access_key:secret_key")
         (ARG_S3ENDPOINTS_LONG, bpo::value(&this->s3EndpointsStr),
-            "Comma-separated list of S3 endpoints. (Format: [http(s)://]hostname[:port])")
+            "Comma-separated list of S3 endpoints. (Format: [http(s)://]hostname[:port]) "
+            "(This can also be set via the " S3_ENV_ENDPOINT_URL_S3 " or "
+            S3_ENV_ENDPOINT_URL " env variable.)")
         (ARG_S3ACCESSKEY_LONG, bpo::value(&this->s3AccessKey),
             "S3 access key. (This can also be set via the " S3_ENV_ACCESS_KEY " env variable.)")
         (ARG_S3ACCESSSECRET_LONG, bpo::value(&this->s3AccessSecret),
@@ -3163,7 +3196,8 @@ void ProgArgs::printHelpS3()
 			"the object size as of which multiple threads are used to upload/download an object. "
 			"(Default: 0, which means " FILESHAREBLOCKFACTOR_STR " x blocksize)")
 		(ARG_S3REGION_LONG, bpo::value(&this->s3Region),
-			"S3 region.")
+			"S3 region. (This can also be set via the " S3_ENV_REGION " or "
+			S3_ENV_REGION_DEFAULT " env variable.)")
 		(ARG_NUMAZONES_LONG, bpo::value(&this->numaZonesStr),
 			"Comma-separated list of NUMA zones to bind this process to. If multiple zones are "
 			"given, then worker threads are bound round-robin to the zones. "


### PR DESCRIPTION
## Summary

Adds AWS CLI v2 env-var fallbacks for `--s3endpoints` and `--s3region`.
CLI args still win. Mirrors the existing `AWS_ACCESS_KEY_ID` pattern.

| Flag            | Env vars (precedence order)                    |
|-----------------|------------------------------------------------|
| `--s3endpoints` | `AWS_ENDPOINT_URL_S3`, `AWS_ENDPOINT_URL`      |
| `--s3region`    | `AWS_REGION`, `AWS_DEFAULT_REGION`             |

## Motivation

Omitting `--s3endpoints` when `AWS_ENDPOINT_URL_S3` is already exported
silently falls through to local-FS mode and fails with a confusing
"Aggregate usable file size" error. Reading the standard env vars fixes
that.

## Notes

- Env-var read happens in `initImplicitValues()` before the
  service-override and credential blocks, so S3-vs-local detection flips
  correctly.
- Skipped in service mode; services inherit from master.
- Behavior change: a stray `AWS_ENDPOINT_URL` now puts elbencho in S3
  mode. Unset it for local-FS runs.

## Test plan

- [x] CLI arg overrides env var.
- [x] Built with `S3_SUPPORT=1` on Linux.
- [ ] Live S3 endpoint, env-var-only run.
- [ ] Distributed run: master→service endpoint inheritance.
